### PR TITLE
feat!: 0.4.0 breaking API improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,31 +24,31 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
 authors = ["WolfSSL Inc."]
 
 [workspace.dependencies]
-secretx-core = { path = "secretx-core", version = "0.3.0" }
-secretx-cache = { path = "secretx-cache", version = "0.3.0" }
-secretx-aws-kms = { path = "secretx-aws-kms", version = "0.3.0" }
-secretx-aws-sm = { path = "secretx-aws-sm", version = "0.3.0" }
-secretx-aws-ssm = { path = "secretx-aws-ssm", version = "0.3.0" }
-secretx-azure-kv = { path = "secretx-azure-kv", version = "0.3.0" }
-secretx-bitwarden = { path = "secretx-bitwarden", version = "0.3.0" }
-secretx-doppler = { path = "secretx-doppler", version = "0.3.0" }
-secretx-env = { path = "secretx-env", version = "0.3.0" }
-secretx-file = { path = "secretx-file", version = "0.3.0" }
-secretx-gcp-sm = { path = "secretx-gcp-sm", version = "0.3.1" }
-secretx-hashicorp-vault = { path = "secretx-hashicorp-vault", version = "0.3.0" }
-secretx-k8s = { path = "secretx-k8s", version = "0.3.0" }
-secretx-keyring = { path = "secretx-keyring", version = "0.3.1" }
-secretx-pkcs11 = { path = "secretx-pkcs11", version = "0.3.0" }
-secretx-wolfhsm = { path = "secretx-wolfhsm", version = "0.3.1" }
-secretx-systemd = { path = "secretx-systemd", version = "0.3.0" }
-secretx-desktop = { path = "secretx-desktop", version = "0.3.0" }
+secretx-core = { path = "secretx-core", version = "0.4.0" }
+secretx-cache = { path = "secretx-cache", version = "0.4.0" }
+secretx-aws-kms = { path = "secretx-aws-kms", version = "0.4.0" }
+secretx-aws-sm = { path = "secretx-aws-sm", version = "0.4.0" }
+secretx-aws-ssm = { path = "secretx-aws-ssm", version = "0.4.0" }
+secretx-azure-kv = { path = "secretx-azure-kv", version = "0.4.0" }
+secretx-bitwarden = { path = "secretx-bitwarden", version = "0.4.0" }
+secretx-doppler = { path = "secretx-doppler", version = "0.4.0" }
+secretx-env = { path = "secretx-env", version = "0.4.0" }
+secretx-file = { path = "secretx-file", version = "0.4.0" }
+secretx-gcp-sm = { path = "secretx-gcp-sm", version = "0.4.0" }
+secretx-hashicorp-vault = { path = "secretx-hashicorp-vault", version = "0.4.0" }
+secretx-k8s = { path = "secretx-k8s", version = "0.4.0" }
+secretx-keyring = { path = "secretx-keyring", version = "0.4.0" }
+secretx-pkcs11 = { path = "secretx-pkcs11", version = "0.4.0" }
+secretx-wolfhsm = { path = "secretx-wolfhsm", version = "0.4.0" }
+secretx-systemd = { path = "secretx-systemd", version = "0.4.0" }
+secretx-desktop = { path = "secretx-desktop", version = "0.4.0" }
 async-trait = "0.1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-kms = "1"
@@ -68,7 +68,7 @@ ed25519-dalek = { version = "2", features = ["pkcs8"] }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 pkcs8 = { version = "0.10", features = ["std"] }
 rsa = { version = "0.9", features = ["sha2", "getrandom"] }
-secretx-local-signing = { path = "secretx-local-signing", version = "0.3.0" }
+secretx-local-signing = { path = "secretx-local-signing", version = "0.4.0" }
 k8s-openapi = { version = "0.27", features = ["v1_32"] }
 kube = { version = "3", features = ["client", "config", "rustls-tls"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend-agnostic secrets retrieval for Rust services and daemons. One trait, man
 
 ```toml
 [dependencies]
-secretx = { version = "0.3", features = ["aws-sm", "file"] }
+secretx = { version = "0.4", features = ["aws-sm", "file"] }
 ```
 
 ---
@@ -38,7 +38,7 @@ choice for desktop apps that need the OS keychain.
 
 - **Not a secrets manager.** Does not store, encrypt, or audit secrets — that is the backend's job.
 - **Not a key management system.** Does not generate keys or rotate credentials autonomously.
-  Exception: the HSM backends (`aws-kms`, `azure-kv`, `pkcs11`) expose `SigningBackend`
+  Exception: the HSM backends (`aws-kms`, `pkcs11`) expose `SigningBackend`
   for keys that must never leave the hardware.
 - **Not a configuration loader.** Loads secrets (sensitive values that must be zeroed on drop),
   not config (non-sensitive structured data). Use `config-rs` or `figment` for the rest.
@@ -64,8 +64,7 @@ secretx:<backend>:<path>[?options]
 | `secretx:aws-sm:prod/my-secret` | AWS Secrets Manager | |
 | `secretx:aws-sm:prod/my-secret?field=password` | AWS Secrets Manager | extract one JSON field |
 | `secretx:aws-ssm:prod/my-param` | AWS SSM Parameter Store | `SecureString` decrypted automatically |
-| `secretx:aws-ssm:prod/my-param?version=3` | AWS SSM Parameter Store | specific version |
-| `secretx:azure-kv:myvault/mysecret` | Azure Key Vault | also `SigningBackend` for HSM vaults |
+| `secretx:azure-kv:myvault/mysecret` | Azure Key Vault | |
 | `secretx:bitwarden:myproject/MY_SECRET` | Bitwarden Secrets Manager | auth via `BWS_ACCESS_TOKEN` |
 | `secretx:doppler:myproject/prd/MY_SECRET` | Doppler | auth via `DOPPLER_TOKEN` |
 | `secretx:gcp-sm:my-project/my-secret` | GCP Secret Manager | |
@@ -73,9 +72,10 @@ secretx:<backend>:<path>[?options]
 | `secretx:desktop:myapp/my-key` | Desktop keychain | macOS Keychain, GNOME Keyring, Windows Credential Manager |
 | `secretx:systemd:<name>` | systemd credentials | `$CREDENTIALS_DIRECTORY`; TPM2-encrypted at rest; requires systemd v250+ |
 | `secretx:local-signing:<path>` | Local key file | signing only; Ed25519, P-256, RSA-PSS |
-| `secretx:pkcs11:0/my-key?lib=/usr/lib/libsofthsm2.so` | PKCS#11 HSM | also `SigningBackend`; `lib` from `PKCS11_LIB` env var |
+| `secretx:pkcs11:0/my-key?lib=/usr/lib/libsofthsm2.so` | PKCS#11 HSM | also `SigningBackend`; `lib` from `PKCS11_LIB`, pin from `PKCS11_PIN` |
 | `secretx:vault:secret/myapp/key` | HashiCorp Vault | auth via `VAULT_TOKEN` or AppRole |
-| `secretx:wolfhsm:my-key` | wolfHSM secure element | transport via `?server=` or `WOLFHSM_SERVER` |
+| `secretx:wolfhsm:my-key?server=host:8080&client_id=1` | wolfHSM secure element | transport via `?server=` or `WOLFHSM_SERVER`; `client_id` 0–255 |
+| `secretx:k8s:default/my-secret` | Kubernetes Secret | `?key=` to select a single data key |
 
 The `from_uri` call constructs the backend and validates the URI syntax. It does not make any
 network call or file read. Fetch happens on first `get`.
@@ -91,12 +91,12 @@ features.
 
 ```toml
 [dependencies]
-secretx = { version = "0.3", features = ["aws-sm", "file"] }
+secretx = { version = "0.4", features = ["aws-sm", "file"] }
 ```
 
 Feature flags match backend names: `aws-kms`, `aws-sm`, `aws-ssm`, `azure-kv`, `bitwarden`,
 `cache`, `desktop`, `doppler`, `env` (default), `file` (default), `gcp-sm`, `hashicorp-vault`,
-`keyring`, `local-signing`, `pkcs11`, `systemd`, `wolfhsm`.
+`k8s`, `keyring`, `local-signing`, `pkcs11`, `systemd`, `wolfhsm`.
 
 ```rust
 use secretx::{SecretStore, SecretValue};
@@ -118,7 +118,7 @@ directly. No umbrella, no feature flags, no compile guards in your dependency tr
 
 ```toml
 [dependencies]
-secretx-aws-sm = "0.3"
+secretx-aws-sm = "0.4"
 ```
 
 ```rust
@@ -131,7 +131,7 @@ let key = store.get().await?;
 
 ### Signing with an HSM-resident key
 
-For keys that must never leave the hardware (AWS KMS, Azure Key Vault HSM, PKCS#11, wolfHSM),
+For keys that must never leave the hardware (AWS KMS, PKCS#11, wolfHSM),
 use `SigningBackend`. Call sites are identical regardless of which HSM is underneath.
 
 ```rust
@@ -153,8 +153,8 @@ let pubkey_der = backend.public_key_der().await?;
 **`SecretStore`** — the main trait: `get` and `refresh`. All backends implement this.
 
 **`WritableSecretStore`** — subtrait that adds `put`. Implemented by backends that support
-writes (file, keyring, cloud stores). Read-only backends (`env`, `bitwarden`) implement only
-`SecretStore`.
+writes (file, keyring, doppler, cloud stores). Read-only backends (`env`, `bitwarden`) implement
+only `SecretStore`.
 
 **`SigningBackend`** — for HSM-resident keys: `sign`, `public_key_der`, `algorithm`. The
 private key never leaves the hardware.
@@ -185,6 +185,7 @@ dispatch functions. Backend crates have no compile-time feature guards.
 | `secretx-doppler` | Doppler backend |
 | `secretx-gcp-sm` | GCP Secret Manager backend |
 | `secretx-hashicorp-vault` | HashiCorp Vault backend |
+| `secretx-k8s` | Kubernetes Secret backend |
 | `secretx-keyring` | Linux kernel keyring backend |
 | `secretx-desktop` | Desktop keychain backend (macOS Keychain, GNOME Keyring, Windows Credential Manager) |
 | `secretx-systemd` | systemd credentials backend (`$CREDENTIALS_DIRECTORY`) |
@@ -206,7 +207,7 @@ README in its crate directory. Contributions welcome; see the roadmap issues in 
 | `secretx-barbican` | `secretx:barbican:<secret-uuid>` | OpenStack Barbican; covers OVHcloud, Open Telekom Cloud, Cleura, STACKIT, VK Cloud, and any OpenStack operator |
 | `secretx-huawei-csms` | `secretx:huawei-csms:<region>/<secret-name>` | Huawei Cloud CSMS (DEW umbrella); OSCCA SM4 available for China-region deployments |
 | `secretx-ibm-sm` | `secretx:ibm-sm:<region>/<instance-id>/<secret-id>` | IBM Cloud Secrets Manager (Vault Enterprise under the hood); for IBM HPCS HSM use `secretx-pkcs11` |
-| `secretx-k8s` | `secretx:k8s:<namespace>/<secret-name>` | Kubernetes Secret object; reads whatever ESO or Secrets Store CSI Driver materialized |
+
 | `secretx-oci-vault` | `secretx:oci-vault:<compartment-id>/<secret-name>` | OCI Vault; also `SigningBackend` for HSM-backed keys |
 | `secretx-scaleway-sm` | `secretx:scaleway-sm:<project-id>/<secret-name>` | Scaleway Secret Manager |
 | `secretx-tencent-ssm` | `secretx:tencent-ssm:<region>/<secret-name>` | Tencent Cloud SSM; OSCCA SM4 available for China-region deployments |
@@ -269,6 +270,7 @@ All backends are implemented. Integration test coverage as of 2026-04-28:
 | `gcp-sm` | ✅ real GCP | tested against GCP Secret Manager; get/put/refresh + CRC32C integrity |
 | `doppler` | ⚠️ unit tests only | needs Doppler account + service token |
 | `bitwarden` | ⚠️ unit tests only | needs Bitwarden Secrets Manager account |
+| `k8s` | ⚠️ unit tests only | needs Kubernetes cluster with accessible Secrets |
 | `keyring` | ✅ kernel keyring headless | Linux only; kernel persistent keyring, no daemon required |
 | `desktop` | ⚠️ unit tests only | needs desktop session; macOS/Windows not yet tested |
 | `systemd` | ⚠️ unit tests only | needs systemd v250+ service environment |

--- a/secretx-alibaba-sm/README.md
+++ b/secretx-alibaba-sm/README.md
@@ -29,8 +29,8 @@ is an OSCCA standard, not FIPS. FIPS 140 certification is not available on this 
 
 ```toml
 [dependencies]
-secretx-alibaba-sm = "0.3"
-secretx-core = "0.3"
+secretx-alibaba-sm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-aws-kms/README.md
+++ b/secretx-aws-kms/README.md
@@ -17,8 +17,8 @@ secretx:aws-kms:<key-id>[?algorithm=<algo>]
 
 ```toml
 [dependencies]
-secretx-aws-kms = "0.2"
-secretx-core = "0.2"
+secretx-aws-kms = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-aws-kms/src/lib.rs
+++ b/secretx-aws-kms/src/lib.rs
@@ -342,13 +342,13 @@ impl SecretStore for AwsKmsBackend {
     }
 }
 
-inventory::submit!(secretx_core::SigningBackendRegistration {
-    name: "aws-kms",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::SigningBackendRegistration::new(
+    "aws-kms",
+    |uri: &str| {
         AwsKmsBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SigningBackend>)
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-aws-sm/README.md
+++ b/secretx-aws-sm/README.md
@@ -16,8 +16,8 @@ secretx:aws-sm:<name>[?field=<json_field>]
 
 ```toml
 [dependencies]
-secretx-aws-sm = "0.2"
-secretx-core = "0.2"
+secretx-aws-sm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-aws-sm/src/lib.rs
+++ b/secretx-aws-sm/src/lib.rs
@@ -256,17 +256,17 @@ impl WritableSecretStore for AwsSmBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "aws-sm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "aws-sm",
+    |uri: &str| {
         AwsSmBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "aws-sm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "aws-sm",
+    |uri: &str| {
         // Reject ?field= at construction time: put() cannot write a single
         // JSON field without a read-modify-write race.  Fail early rather than
         // returning InvalidUri from put() at rotation time.
@@ -284,7 +284,7 @@ inventory::submit!(secretx_core::WritableBackendRegistration {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-aws-ssm/README.md
+++ b/secretx-aws-ssm/README.md
@@ -19,8 +19,8 @@ SSM paths that start with `/` use a leading `/` in the path component of the URI
 
 ```toml
 [dependencies]
-secretx-aws-ssm = "0.2"
-secretx-core = "0.2"
+secretx-aws-ssm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-aws-ssm/src/lib.rs
+++ b/secretx-aws-ssm/src/lib.rs
@@ -242,22 +242,22 @@ impl WritableSecretStore for AwsSsmBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "aws-ssm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "aws-ssm",
+    |uri: &str| {
         AwsSsmBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "aws-ssm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "aws-ssm",
+    |uri: &str| {
         AwsSsmBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-azure-kv/README.md
+++ b/secretx-azure-kv/README.md
@@ -22,8 +22,8 @@ Credential modes:
 
 ```toml
 [dependencies]
-secretx-azure-kv = "0.2"
-secretx-core = "0.2"
+secretx-azure-kv = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust
@@ -37,3 +37,5 @@ let value = store.get().await?;
 ## Part of secretx
 
 This crate is part of the [secretx](https://crates.io/crates/secretx) workspace. Enable the `azure-kv` feature on the `secretx` umbrella crate to use it via URI dispatch.
+
+`SigningBackend` is not implemented by this crate.

--- a/secretx-azure-kv/src/lib.rs
+++ b/secretx-azure-kv/src/lib.rs
@@ -372,17 +372,17 @@ impl WritableSecretStore for AzureKvBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "azure-kv",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "azure-kv",
+    |uri: &str| {
         AzureKvBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "azure-kv",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "azure-kv",
+    |uri: &str| {
         // Reject ?field= at construction time: put() cannot write a single
         // JSON field without a read-modify-write race.  Fail early rather than
         // returning InvalidUri from put() at rotation time.
@@ -400,7 +400,7 @@ inventory::submit!(secretx_core::WritableBackendRegistration {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-barbican/README.md
+++ b/secretx-barbican/README.md
@@ -58,8 +58,8 @@ installation:
 
 ```toml
 [dependencies]
-secretx-barbican = "0.3"
-secretx-core = "0.3"
+secretx-barbican = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-bitwarden/README.md
+++ b/secretx-bitwarden/README.md
@@ -5,10 +5,10 @@ Bitwarden Secrets Manager backend for [secretx](https://crates.io/crates/secretx
 ## URI
 
 ```text
-secretx:bitwarden:<project-id>/<secret-name>
+secretx:bitwarden:<project-name>/<secret-name>
 ```
 
-- `project-id` — Bitwarden project UUID
+- `project-name` — Bitwarden project name (looked up by name, not UUID)
 - `secret-name` — secret name within the project
 
 Requires `BWS_ACCESS_TOKEN` to be set in the environment at construction time. Obtain a machine account access token from the Bitwarden Secrets Manager console.
@@ -17,8 +17,8 @@ Requires `BWS_ACCESS_TOKEN` to be set in the environment at construction time. O
 
 ```toml
 [dependencies]
-secretx-bitwarden = "0.2"
-secretx-core = "0.2"
+secretx-bitwarden = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust
@@ -26,7 +26,7 @@ use secretx_bitwarden::BitwardenBackend;
 use secretx_core::SecretStore;
 
 let store = BitwardenBackend::from_uri(
-    "secretx:bitwarden:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/DB_PASSWORD",
+    "secretx:bitwarden:my-project/DB_PASSWORD",
 )?;
 let value = store.get().await?;
 ```

--- a/secretx-bitwarden/src/lib.rs
+++ b/secretx-bitwarden/src/lib.rs
@@ -346,13 +346,13 @@ impl SecretStore for BitwardenBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "bitwarden",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "bitwarden",
+    |uri: &str| {
         BitwardenBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-cache/README.md
+++ b/secretx-cache/README.md
@@ -8,9 +8,9 @@ TTL-based in-memory cache wrapping any `SecretStore` — part of the [secretx](h
 
 ```toml
 [dependencies]
-secretx-cache = "0.2"
-secretx-aws-sm = "0.2"  # or any other backend
-secretx-core = "0.2"
+secretx-cache = "0.4"
+secretx-aws-sm = "0.4"  # or any other backend
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-core/README.md
+++ b/secretx-core/README.md
@@ -6,7 +6,7 @@ Core traits and types for the [secretx](https://crates.io/crates/secretx) secret
 
 ## Key types
 
-**`SecretStore`** — the main async trait: `get`, `put`, `refresh`. All backends implement this.
+**`SecretStore`** — the main async trait: `get` and `refresh`. All backends implement this.
 
 **`SigningBackend`** — for HSM-resident keys that must never leave hardware: `sign`, `public_key_der`, `algorithm`.
 
@@ -22,7 +22,7 @@ Application code depends on `secretx-core` for trait methods and error handling.
 
 ```toml
 [dependencies]
-secretx-core = "0.2"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-core/src/lib.rs
+++ b/secretx-core/src/lib.rs
@@ -1345,19 +1345,14 @@ pub trait SigningBackend: Send + Sync {
 
     /// Key algorithm identifier.
     ///
-    /// Returns an error if the backend cannot determine the algorithm (e.g. the
-    /// HSM is offline).  For backends where the algorithm is fixed at
-    /// construction time (AWS KMS, local-signing) this always returns `Ok`.
+    /// For backends where the algorithm is fixed at construction time (AWS KMS,
+    /// local-signing) this always returns `Ok`.
     ///
-    /// # Blocking note
-    ///
-    /// This method is synchronous.  HSM-backed implementations (e.g. PKCS#11)
-    /// may open an HSM session on the first call to detect the key type, which
-    /// can block the calling thread for tens of milliseconds.  If you are
-    /// calling this from async code and the algorithm is not yet cached, prefer
-    /// calling [`sign`](SigningBackend::sign) or
-    /// [`public_key_der`](SigningBackend::public_key_der) first — those methods
-    /// use `spawn_blocking` and populate the algorithm cache as a side effect.
+    /// HSM-backed implementations (e.g. PKCS#11) may require a prior call to
+    /// [`sign`](SigningBackend::sign) or
+    /// [`public_key_der`](SigningBackend::public_key_der) to detect and cache
+    /// the key type.  If the cache is cold, `algorithm()` returns an error
+    /// rather than blocking on HSM I/O.
     fn algorithm(&self) -> Result<SigningAlgorithm, SecretError>;
 }
 
@@ -1479,29 +1474,62 @@ pub fn get_blocking<S: SecretStore + ?Sized>(store: &S) -> Result<SecretValue, S
 // ── Backend registration ──────────────────────────────────────────────────────
 
 /// Registration entry for a [`SecretStore`] backend.
+#[non_exhaustive]
 pub struct BackendRegistration {
     /// Backend scheme name (e.g. `"env"`, `"file"`, `"aws-sm"`).
     pub name: &'static str,
     /// Factory function: construct a backend from a URI string.
     pub factory: fn(&str) -> Result<std::sync::Arc<dyn SecretStore>, SecretError>,
 }
+
+impl BackendRegistration {
+    /// Create a new registration entry.
+    pub const fn new(
+        name: &'static str,
+        factory: fn(&str) -> Result<std::sync::Arc<dyn SecretStore>, SecretError>,
+    ) -> Self {
+        Self { name, factory }
+    }
+}
 inventory::collect!(BackendRegistration);
 
 /// Registration entry for a [`WritableSecretStore`] backend.
+#[non_exhaustive]
 pub struct WritableBackendRegistration {
     /// Backend scheme name.
     pub name: &'static str,
     /// Factory function: construct a writable backend from a URI string.
     pub factory: fn(&str) -> Result<std::sync::Arc<dyn WritableSecretStore>, SecretError>,
 }
+
+impl WritableBackendRegistration {
+    /// Create a new registration entry.
+    pub const fn new(
+        name: &'static str,
+        factory: fn(&str) -> Result<std::sync::Arc<dyn WritableSecretStore>, SecretError>,
+    ) -> Self {
+        Self { name, factory }
+    }
+}
 inventory::collect!(WritableBackendRegistration);
 
 /// Registration entry for a [`SigningBackend`] backend.
+#[non_exhaustive]
 pub struct SigningBackendRegistration {
     /// Backend scheme name.
     pub name: &'static str,
     /// Factory function: construct a signing backend from a URI string.
     pub factory: fn(&str) -> Result<std::sync::Arc<dyn SigningBackend>, SecretError>,
+}
+
+impl SigningBackendRegistration {
+    /// Create a new registration entry.
+    pub const fn new(
+        name: &'static str,
+        factory: fn(&str) -> Result<std::sync::Arc<dyn SigningBackend>, SecretError>,
+    ) -> Self {
+        Self { name, factory }
+    }
 }
 inventory::collect!(SigningBackendRegistration);
 

--- a/secretx-desktop/README.md
+++ b/secretx-desktop/README.md
@@ -23,8 +23,8 @@ secretx:desktop:<service>/<account>
 
 ```toml
 [dependencies]
-secretx-desktop = "0.3"
-secretx-core = "0.3"
+secretx-desktop = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-desktop/src/lib.rs
+++ b/secretx-desktop/src/lib.rs
@@ -178,22 +178,22 @@ impl WritableSecretStore for DesktopKeyringBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "desktop",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "desktop",
+    |uri: &str| {
         DesktopKeyringBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "desktop",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "desktop",
+    |uri: &str| {
         DesktopKeyringBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-doppler/README.md
+++ b/secretx-doppler/README.md
@@ -18,8 +18,8 @@ Requires `DOPPLER_TOKEN` to be set in the environment at construction time.
 
 ```toml
 [dependencies]
-secretx-doppler = "0.2"
-secretx-core = "0.2"
+secretx-doppler = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust
@@ -29,6 +29,10 @@ use secretx_core::SecretStore;
 let store = DopplerBackend::from_uri("secretx:doppler:myproject/prd/DB_PASSWORD")?;
 let value = store.get().await?;
 ```
+
+## WritableSecretStore
+
+`put()` is supported via `WritableSecretStore`. It writes the secret value back to Doppler using the Secrets API.
 
 ## Part of secretx
 

--- a/secretx-doppler/src/lib.rs
+++ b/secretx-doppler/src/lib.rs
@@ -241,22 +241,22 @@ impl WritableSecretStore for DopplerBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "doppler",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "doppler",
+    |uri: &str| {
         DopplerBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "doppler",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "doppler",
+    |uri: &str| {
         DopplerBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-env/README.md
+++ b/secretx-env/README.md
@@ -14,8 +14,8 @@ secretx:env:<VAR_NAME>
 
 ```toml
 [dependencies]
-secretx-env = "0.2"
-secretx-core = "0.2"
+secretx-env = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-env/src/lib.rs
+++ b/secretx-env/src/lib.rs
@@ -72,13 +72,13 @@ impl SecretStore for EnvBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "env",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "env",
+    |uri: &str| {
         EnvBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-file/README.md
+++ b/secretx-file/README.md
@@ -17,8 +17,8 @@ secretx:file:relative/path          →  reads relative/path
 
 ```toml
 [dependencies]
-secretx-file = "0.2"
-secretx-core = "0.2"
+secretx-file = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-file/src/lib.rs
+++ b/secretx-file/src/lib.rs
@@ -231,22 +231,22 @@ fn write_secret_file(path: &std::path::Path, data: &[u8]) -> std::io::Result<()>
     Ok(())
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "file",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "file",
+    |uri: &str| {
         FileBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "file",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "file",
+    |uri: &str| {
         FileBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-gcp-sm/Cargo.toml
+++ b/secretx-gcp-sm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secretx-gcp-sm"
-version = "0.3.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/secretx-gcp-sm/README.md
+++ b/secretx-gcp-sm/README.md
@@ -20,8 +20,8 @@ Requires `GCP_ACCESS_TOKEN` to be set in the environment at construction time. O
 
 ```toml
 [dependencies]
-secretx-gcp-sm = "0.3"
-secretx-core = "0.3"
+secretx-gcp-sm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-gcp-sm/src/lib.rs
+++ b/secretx-gcp-sm/src/lib.rs
@@ -403,22 +403,22 @@ impl WritableSecretStore for GcpSmBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "gcp-sm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "gcp-sm",
+    |uri: &str| {
         GcpSmBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "gcp-sm",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "gcp-sm",
+    |uri: &str| {
         GcpSmBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-hashicorp-vault/README.md
+++ b/secretx-hashicorp-vault/README.md
@@ -19,8 +19,8 @@ secretx:vault:<mount>/<secret-path>[?field=<json_field>&addr=<vault_addr>]
 
 ```toml
 [dependencies]
-secretx-hashicorp-vault = "0.2"
-secretx-core = "0.2"
+secretx-hashicorp-vault = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-hashicorp-vault/src/lib.rs
+++ b/secretx-hashicorp-vault/src/lib.rs
@@ -324,22 +324,22 @@ impl WritableSecretStore for VaultBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "vault",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "vault",
+    |uri: &str| {
         VaultBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "vault",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "vault",
+    |uri: &str| {
         VaultBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-huawei-csms/README.md
+++ b/secretx-huawei-csms/README.md
@@ -37,8 +37,8 @@ not available on this backend.
 
 ```toml
 [dependencies]
-secretx-huawei-csms = "0.3"
-secretx-core = "0.3"
+secretx-huawei-csms = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-ibm-sm/README.md
+++ b/secretx-ibm-sm/README.md
@@ -33,8 +33,8 @@ endpoint today.
 
 ```toml
 [dependencies]
-secretx-ibm-sm = "0.3"
-secretx-core = "0.3"
+secretx-ibm-sm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-k8s/README.md
+++ b/secretx-k8s/README.md
@@ -60,8 +60,8 @@ pod volume mount or env var entry.
 
 ```toml
 [dependencies]
-secretx-k8s = "0.3"
-secretx-core = "0.3"
+secretx-k8s = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-k8s/src/lib.rs
+++ b/secretx-k8s/src/lib.rs
@@ -252,22 +252,22 @@ impl secretx_core::WritableSecretStore for K8sBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: BACKEND,
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    BACKEND,
+    |uri: &str| {
         K8sBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: BACKEND,
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    BACKEND,
+    |uri: &str| {
         K8sBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 //

--- a/secretx-keyring/Cargo.toml
+++ b/secretx-keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secretx-keyring"
-version = "0.3.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/secretx-keyring/README.md
+++ b/secretx-keyring/README.md
@@ -21,8 +21,8 @@ Linux only. Requires kernel keyutils support (standard on all modern Linux distr
 
 ```toml
 [dependencies]
-secretx-keyring = "0.3"
-secretx-core = "0.3"
+secretx-keyring = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust
@@ -38,7 +38,7 @@ let value = store.get().await?;
 - Secrets are stored in kernel memory — never written to disk as plaintext.
 - Access is controlled by the kernel's UID-based keyring permissions.
 - The persistent keyring survives reboots but expires after a configurable window (default: a few days).
-- For encrypted-at-rest storage, consider `secretx-systemd-creds` (TPM2-encrypted, tmpfs-backed) or a cloud backend.
+- For encrypted-at-rest storage, consider `secretx-systemd` (TPM2-encrypted, tmpfs-backed) or a cloud backend.
 
 ## Part of secretx
 

--- a/secretx-keyring/src/lib.rs
+++ b/secretx-keyring/src/lib.rs
@@ -189,23 +189,23 @@ impl WritableSecretStore for KeyringBackend {
 }
 
 #[cfg(target_os = "linux")]
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "keyring",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "keyring",
+    |uri: &str| {
         KeyringBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
 #[cfg(target_os = "linux")]
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "keyring",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "keyring",
+    |uri: &str| {
         KeyringBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-local-signing/README.md
+++ b/secretx-local-signing/README.md
@@ -21,8 +21,8 @@ secretx:local-signing:/etc/secrets/rsa.der?algorithm=rsa-pss-2048
 
 ```toml
 [dependencies]
-secretx-local-signing = "0.2"
-secretx-core = "0.2"
+secretx-local-signing = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-local-signing/src/lib.rs
+++ b/secretx-local-signing/src/lib.rs
@@ -262,13 +262,13 @@ impl SigningBackend for LocalSigningBackend {
     }
 }
 
-inventory::submit!(secretx_core::SigningBackendRegistration {
-    name: "local-signing",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::SigningBackendRegistration::new(
+    "local-signing",
+    |uri: &str| {
         LocalSigningBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SigningBackend>)
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-oci-vault/README.md
+++ b/secretx-oci-vault/README.md
@@ -33,8 +33,8 @@ This maps to the OCI Vault Cryptographic Operations service. The private key nev
 
 ```toml
 [dependencies]
-secretx-oci-vault = "0.3"
-secretx-core = "0.3"
+secretx-oci-vault = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-pkcs11/README.md
+++ b/secretx-pkcs11/README.md
@@ -19,8 +19,8 @@ secretx:pkcs11:<slot>/<label>[?lib=<path>&pin=<pin>]
 
 ```toml
 [dependencies]
-secretx-pkcs11 = "0.2"
-secretx-core = "0.2"
+secretx-pkcs11 = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-pkcs11/src/lib.rs
+++ b/secretx-pkcs11/src/lib.rs
@@ -48,9 +48,10 @@ pub struct Pkcs11Backend {
     slot: cryptoki::slot::Slot,
     label: String,
     user_pin: Option<Zeroizing<String>>,
-    // Cached result of detect_algorithm(). Populated on first call to algorithm().
-    // Arc<OnceLock> so the cache can be shared with spawn_blocking closures without
-    // requiring &self to be 'static.
+    // Cached algorithm, populated by sign() on first call.  algorithm() reads
+    // this cache but never performs I/O itself.
+    // Arc<OnceLock> so the cache can be shared with spawn_blocking closures
+    // without requiring &self to be 'static.
     algorithm_cache: Arc<std::sync::OnceLock<SigningAlgorithm>>,
 }
 
@@ -143,14 +144,6 @@ impl Pkcs11Backend {
                 source: e.into(),
             })?;
         handles.into_iter().next().ok_or(SecretError::NotFound)
-    }
-
-    /// Determine the key algorithm stored under `self.label`.
-    ///
-    /// Inspects `CKA_KEY_TYPE` of the `CKO_PRIVATE_KEY` object. For EC keys,
-    /// also reads `CKA_EC_PARAMS` and verifies the curve is P-256.
-    fn detect_algorithm(&self) -> Result<SigningAlgorithm, SecretError> {
-        pkcs11_detect_algorithm(&self.ctx, self.slot, &self.label, &self.user_pin)
     }
 
     /// Read `CKA_MODULUS_BITS` from an RSA private key and verify the key size.
@@ -594,53 +587,45 @@ impl SigningBackend for Pkcs11Backend {
         })?
     }
 
-    /// Returns the algorithm based on `CKA_KEY_TYPE` of the private key object.
+    /// Returns the cached algorithm, or errors if the cache is cold.
     ///
-    /// Returns `Err` if the HSM is unreachable or no private key object with
-    /// this label exists.  The result is cached after the first successful call
-    /// so subsequent invocations do not open an HSM session.
-    ///
-    /// Note: this is a synchronous method (required by the `SigningBackend` trait).
-    /// On the first call (cold cache) it opens an HSM session, which blocks the
-    /// current thread.  When called from async code, prefer calling `sign()` or
-    /// `public_key_der()` directly — those methods dispatch all HSM I/O via
-    /// `spawn_blocking` and populate the cache as a side effect.
+    /// This method never performs HSM I/O.  Call [`sign`](SigningBackend::sign)
+    /// or [`public_key_der`](SigningBackend::public_key_der) first to detect
+    /// the key type and warm the cache.
     fn algorithm(&self) -> Result<SigningAlgorithm, SecretError> {
-        // Return the cached value if a previous call succeeded.
-        if let Some(&algo) = self.algorithm_cache.get() {
-            return Ok(algo);
-        }
-        let algo = self.detect_algorithm()?;
-        // Best-effort cache: if another thread raced us, discard our result.
-        let _ = self.algorithm_cache.set(algo);
-        Ok(algo)
+        self.algorithm_cache.get().copied().ok_or_else(|| SecretError::Backend {
+            backend: "pkcs11",
+            source: "algorithm not yet detected; call sign() or public_key_der() first \
+                     to warm the cache"
+                .into(),
+        })
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "pkcs11",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "pkcs11",
+    |uri: &str| {
         Pkcs11Backend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::SigningBackendRegistration {
-    name: "pkcs11",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::SigningBackendRegistration::new(
+    "pkcs11",
+    |uri: &str| {
         Pkcs11Backend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SigningBackend>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: "pkcs11",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    "pkcs11",
+    |uri: &str| {
         Pkcs11Backend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/secretx-scaleway-sm/README.md
+++ b/secretx-scaleway-sm/README.md
@@ -23,8 +23,8 @@ secretx:scaleway-sm:<project-id>/<secret-name>[?field=<json_field>&revision=<n>&
 
 ```toml
 [dependencies]
-secretx-scaleway-sm = "0.3"
-secretx-core = "0.3"
+secretx-scaleway-sm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-systemd/README.md
+++ b/secretx-systemd/README.md
@@ -29,8 +29,8 @@ systemd-creds encrypt --with-key=tpm2 secret.txt /etc/credentials/db-password.cr
 
 ```toml
 [dependencies]
-secretx-systemd = "0.3"
-secretx-core = "0.3"
+secretx-systemd = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-systemd/src/lib.rs
+++ b/secretx-systemd/src/lib.rs
@@ -125,13 +125,13 @@ impl SecretStore for SystemdCredsBackend {
     }
 }
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: "systemd",
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    "systemd",
+    |uri: &str| {
         SystemdCredsBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
 #[cfg(test)]
 mod tests {

--- a/secretx-tencent-ssm/README.md
+++ b/secretx-tencent-ssm/README.md
@@ -28,8 +28,8 @@ FIPS 140 certification is not available on this backend.
 
 ```toml
 [dependencies]
-secretx-tencent-ssm = "0.3"
-secretx-core = "0.3"
+secretx-tencent-ssm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx-wolfhsm/Cargo.toml
+++ b/secretx-wolfhsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secretx-wolfhsm"
-version = "0.3.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/secretx-wolfhsm/README.md
+++ b/secretx-wolfhsm/README.md
@@ -9,7 +9,7 @@ wolfHSM C library. `SigningBackend` is declared but returns `Unavailable` until
 ## URI
 
 ```text
-secretx:wolfhsm:<label>[?server=<addr>][?client_id=<n>]
+secretx:wolfhsm:<label>[?server=<addr>&client_id=<n>]
 ```
 
 - `label` — NVM object label (1–24 bytes, UTF-8)
@@ -29,8 +29,8 @@ connection). `WOLFHSM_SERVER` is validated at first use.
 
 ```toml
 [dependencies]
-secretx-wolfhsm = "0.3"
-secretx-core = "0.3"
+secretx-wolfhsm = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust
@@ -59,7 +59,7 @@ object before adding the new one. If the add fails after the delete,
 
 ```toml
 [dependencies]
-secretx = { version = "0.3", features = ["wolfhsm"] }
+secretx = { version = "0.4", features = ["wolfhsm"] }
 ```
 
 ```rust

--- a/secretx-wolfhsm/src/lib.rs
+++ b/secretx-wolfhsm/src/lib.rs
@@ -535,22 +535,22 @@ fn signing_unavailable(label: &str) -> SecretError {
 
 // ── Inventory registrations ───────────────────────────────────────────────────
 
-inventory::submit!(secretx_core::BackendRegistration {
-    name: BACKEND,
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::BackendRegistration::new(
+    BACKEND,
+    |uri: &str| {
         WolfHsmBackend::from_uri(uri)
             .map(|b| std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::SecretStore>)
     },
-});
+));
 
-inventory::submit!(secretx_core::WritableBackendRegistration {
-    name: BACKEND,
-    factory: |uri: &str| {
+inventory::submit!(secretx_core::WritableBackendRegistration::new(
+    BACKEND,
+    |uri: &str| {
         WolfHsmBackend::from_uri(uri).map(|b| {
             std::sync::Arc::new(b) as std::sync::Arc<dyn secretx_core::WritableSecretStore>
         })
     },
-});
+));
 
 // SigningBackendRegistration is intentionally NOT registered: the wolfhsm
 // crate does not yet expose EccP256Key::load_from_nvm, so all SigningBackend

--- a/secretx-yandex-lockbox/README.md
+++ b/secretx-yandex-lockbox/README.md
@@ -29,8 +29,8 @@ multi-entry secrets, use `?field=` to be explicit.
 
 ```toml
 [dependencies]
-secretx-yandex-lockbox = "0.3"
-secretx-core = "0.3"
+secretx-yandex-lockbox = "0.4"
+secretx-core = "0.4"
 ```
 
 ```rust

--- a/secretx/Cargo.toml
+++ b/secretx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secretx"
-version = "0.3.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- **`SigningBackend::algorithm()` no longer blocks on cold cache** — pkcs11 implementation now returns an error if the algorithm cache hasn't been warmed by a prior `sign()` or `public_key_der()` call, instead of performing blocking HSM I/O from a sync method
- **`BackendRegistration` structs are `#[non_exhaustive]`** — all three registration structs (`BackendRegistration`, `WritableBackendRegistration`, `SigningBackendRegistration`) now have `#[non_exhaustive]` and `::new()` constructors; all 30 `inventory::submit!` calls updated
- **All crates unified at 0.4.0** — gcp-sm, keyring, wolfhsm, and the umbrella crate (previously at independent 0.3.1) now use `version.workspace = true`

## Breaking changes

1. `SigningBackend::algorithm()` on `Pkcs11Backend` returns `Err(Backend)` if algorithm cache is cold. Call `sign()` or `public_key_der()` first.
2. `BackendRegistration`, `WritableBackendRegistration`, `SigningBackendRegistration` can no longer be constructed with struct literal syntax from outside `secretx-core`. Use `::new(name, factory)`.

## Test plan

- [x] `cargo check --workspace --exclude secretx-wolfhsm` passes
- [x] `cargo test --workspace --exclude secretx-wolfhsm` — all tests pass (wolfhsm excluded due to missing C sources, not related to this PR)